### PR TITLE
57 remove redundant csv saving when saving hirds data to database

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,19 +194,17 @@ if __name__ == "__main__":
     from src.dynamic_boundary_conditions import hirds_rainfall_data_to_db
     
     catchment_file = pathlib.Path(r"src\dynamic_boundary_conditions\catchment_polygon.shp")
-    file_path_to_store = pathlib.Path(r"U:\Research\FloodRiskResearch\DigitalTwin\hirds_rainfall_data")
     engine = setup_environment.get_database()
     catchment_polygon = hyetograph.catchment_area_geometry_info(catchment_file)
     # Set idf to False for rain depth data and to True for rain intensity data
-    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, file_path_to_store, idf=False)
-    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, file_path_to_store, idf=True)
+    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, idf=False)
+    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, idf=True)
 ```
 
-The `rainfall_data_to_db(engine, catchment_polygon, path, idf)` function requires four arguments:
+The `rainfall_data_to_db(engine, catchment_polygon, idf)` function requires three arguments:
 1. *engine:* Engine used to connect to the database.
 2. *catchment_polygon:* Desired catchment area (polygon type).
-3. *path:* The file path of where the downloaded rainfall data CSV files are stored.
-4. *idf:* Set to False for rainfall depth data, and True for rainfall intensity data.
+3. *idf:* Set to False for rainfall depth data, and True for rainfall intensity data.
 
 <br>
 
@@ -295,7 +293,6 @@ A hyetograph is a graphical representation of the distribution of rainfall inten
 >    from src.dynamic_boundary_conditions import hirds_rainfall_data_from_db
 >
 >    catchment_file = pathlib.Path(r"src\dynamic_boundary_conditions\catchment_polygon.shp")
->    file_path_to_store = pathlib.Path(r"U:\Research\FloodRiskResearch\DigitalTwin\hirds_rainfall_data")
 >    rcp = 2.6
 >    time_period = "2031-2050"
 >    ari = 100
@@ -305,15 +302,20 @@ A hyetograph is a graphical representation of the distribution of rainfall inten
 >    engine = setup_environment.get_database()
 >    sites = rainfall_sites.get_rainfall_sites_data()
 >    rainfall_sites.rainfall_sites_to_db(engine, sites)
->    nz_boundary = rainfall_sites.get_new_zealand_boundary(engine)
->    sites_in_catchment = rainfall_sites.get_sites_locations(engine, nz_boundary)
->    thiessen_polygon_calculator.thiessen_polygons(engine, nz_boundary, sites_in_catchment)
+>    nz_boundary_polygon = rainfall_sites.get_new_zealand_boundary(engine)
+>    sites_in_catchment = rainfall_sites.get_sites_locations(engine, nz_boundary_polygon)
+>    thiessen_polygon_calculator.thiessen_polygons(engine, nz_boundary_polygon, sites_in_catchment)
 >    catchment_polygon = hyetograph.catchment_area_geometry_info(catchment_file)
+>
 >    # Set idf to False for rain depth data and to True for rain intensity data
->    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, file_path_to_store, idf=False)
+>    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, idf=False)
+>    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, idf=True)
 >    rain_depth_in_catchment = hirds_rainfall_data_from_db.rainfall_data_from_db(
->        engine, catchment_polygon, rcp, time_period, ari, duration)
+>        engine, catchment_polygon, rcp, time_period, ari, duration, idf=False)
 >    print(rain_depth_in_catchment)
+>    rain_intensity_in_catchment = hirds_rainfall_data_from_db.rainfall_data_from_db(
+>        engine, catchment_polygon, rcp, time_period, ari, duration, idf=True)
+>    print(rain_intensity_in_catchment)
 >```
 
 <br>

--- a/src/dynamic_boundary_conditions/hirds_rainfall_data_from_db.py
+++ b/src/dynamic_boundary_conditions/hirds_rainfall_data_from_db.py
@@ -13,9 +13,9 @@ import pathlib
 import logging
 import sys
 from shapely.geometry import Polygon
-from src.dynamic_boundary_conditions import hirds_rainfall_data_to_db
 from src.digitaltwin import setup_environment
 from src.dynamic_boundary_conditions import hyetograph
+from src.dynamic_boundary_conditions import hirds_rainfall_data_to_db
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/src/dynamic_boundary_conditions/hirds_rainfall_data_to_db.py
+++ b/src/dynamic_boundary_conditions/hirds_rainfall_data_to_db.py
@@ -5,16 +5,15 @@
 @Author: pkh35
 @Date: 20/01/2022
 @Last modified by: sli229
-@Last modified date: 28/09/2022
+@Last modified date: 4/10/2022
 """
 
-import re
 import pandas as pd
 import geopandas as gpd
 import sqlalchemy
 import pathlib
 import logging
-from typing import List, Tuple
+from typing import List
 from shapely.geometry import Polygon
 from src.digitaltwin import setup_environment
 from src.dynamic_boundary_conditions import hyetograph
@@ -100,72 +99,9 @@ def get_sites_id_not_in_db(engine, sites_id_in_catchment: List[str], idf: bool) 
     return sites_id_not_in_db
 
 
-def get_layout_structure_of_csv(filepath) -> List[Tuple[int, float, str]]:
-    """
-    Read the rainfall data CSV file and return a list of tuples (skip_rows, rcp, time_period) of its layout structure.
-
-    Parameters
-    ----------
-    filepath
-        The file path of the downloaded rainfall data CSV files.
-    """
-    skip_rows = []
-    rcp = []
-    time_period = []
-    # Read file line by line with a for loop
-    with open(filepath) as file:
-        for index, line in enumerate(file):
-            # Get lines that contain "(mm) ::" for depth data or "(mm/hr) ::" for intensity data
-            if (line.find("(mm) ::") != -1) or (line.find("(mm/hr) ::") != -1):
-                # Add the row number to skip_rows list
-                skip_rows.append(index + 1)
-                # Add the obtained rcp and time_period values to list
-                rcp_result = re.search(r"(\d*\.\d*)", line)
-                period_result = re.search(r"(\d{4}-\d{4})", line)
-                if rcp_result or period_result is not None:
-                    rcp.append(float(rcp_result[0]))
-                    time_period.append(period_result[0])
-                else:
-                    rcp.append(float('nan'))
-                    time_period.append(None)
-    # Merge the three different lists into one list of tuples
-    layout_structure = list(zip(skip_rows, rcp, time_period))
-    return layout_structure
-
-
-def get_data_from_csv(filepath, site_id: str, skip_rows: int, rcp: float, time_period: str) -> pd.DataFrame:
-    """
-    Read the rainfall data CSV file and return the required data in Pandas DataFrame format.
-
-    Parameters
-    ----------
-    filepath
-        The file path of the downloaded rainfall data CSV files.
-    site_id : str
-        HIRDS rainfall site id.
-    skip_rows : int
-        Number of lines to skip at the start of the CSV file.
-    rcp : float
-        There are four different representative concentration pathways (RCPs), and abbreviated as RCP2.6, RCP4.5,
-        RCP6.0 and RCP8.5, in order of increasing radiative forcing by greenhouse gases.
-    time_period : str
-        Rainfall estimates for two future time periods (e.g. 2031-2050 or 2081-2100) for four RCPs.
-    """
-    rainfall_data = pd.read_csv(filepath, skiprows=skip_rows, nrows=12)
-    rainfall_data.insert(0, "site_id", site_id)
-    rainfall_data.insert(1, "rcp", rcp)
-    rainfall_data.insert(2, "time_period", time_period)
-    rainfall_data.columns = rainfall_data.columns.str.lower()
-    return rainfall_data
-
-
-def add_rainfall_data_to_db(engine, site_id: str, path, idf: bool):
+def add_rainfall_data_to_db(engine, site_id: str, idf: bool):
     """
     Store each site's rainfall data in the database.
-    Each CSV file contains historical and future forecasted rainfall data for various rcp, time periods and durations.
-    To view the CSV file, go to https://hirds.niwa.co.nz/, select a site and generate a report,
-    there are rainfall depths and rainfall intensities data for different RCP Scenarios.
-    To understand the structure of the CSV file, download the spreadsheet.
 
     Parameters
     ----------
@@ -173,27 +109,23 @@ def add_rainfall_data_to_db(engine, site_id: str, path, idf: bool):
         Engine used to connect to the database.
     site_id : str
         HIRDS rainfall site id.
-    path
-        The file path of where the downloaded rainfall data CSV files are stored.
     idf : bool
         Set to False for rainfall depth data, and True for rainfall intensity data.
     """
     rain_table_name = db_rain_table_name(idf)
-    filename = pathlib.Path(f"{site_id}_{rain_table_name}.csv")
-    filepath = (path / filename)
-
-    layout_structure = get_layout_structure_of_csv(filepath)
+    site_data = rainfall_data_from_hirds.get_data_from_hirds(site_id, idf)
+    layout_structure = rainfall_data_from_hirds.get_layout_structure_of_data(site_data)
 
     for (skip_rows, rcp, time_period) in layout_structure:
-        site_data = get_data_from_csv(filepath, site_id, skip_rows=skip_rows, rcp=rcp, time_period=time_period)
-        site_data.to_sql(rain_table_name, engine, index=False, if_exists="append")
+        rain_data = rainfall_data_from_hirds.convert_to_tabular_data(
+            site_data, site_id, skip_rows=skip_rows, rcp=rcp, time_period=time_period)
+        rain_data.to_sql(rain_table_name, engine, index=False, if_exists="append")
     log.info(f"Added {rain_table_name} data for site {site_id} to database")
 
 
-def add_each_site_rainfall_data(engine, sites_id_list: List[str], path: str, idf: bool):
+def add_each_site_rainfall_data(engine, sites_id_list: List[str], idf: bool):
     """
-    Loop through all the sites in the sites_id_list, download and store each site's rainfall data as a CSV file
-    in the desired file path, and then read the CSV files to store the rainfall data in the database.
+    Loop through all the sites in the sites_id_list, and store each site's rainfall data in the database.
 
     Parameters
     ----------
@@ -201,17 +133,14 @@ def add_each_site_rainfall_data(engine, sites_id_list: List[str], path: str, idf
         Engine used to connect to the database.
     sites_id_list : List[str]
         Rainfall sites' ids.
-    path
-        The file path of where the downloaded rainfall data CSV files are stored.
     idf : bool
         Set to False for rainfall depth data, and True for rainfall intensity data.
     """
     for site_id in sites_id_list:
-        rainfall_data_from_hirds.store_data_to_csv(site_id, path, idf)
-        add_rainfall_data_to_db(engine, site_id, path, idf)
+        add_rainfall_data_to_db(engine, site_id, idf)
 
 
-def rainfall_data_to_db(engine, catchment_polygon: Polygon, path, idf: bool):
+def rainfall_data_to_db(engine, catchment_polygon: Polygon, idf: bool):
     """
     Store rainfall data of all the sites within the catchment area in the database.
 
@@ -221,8 +150,6 @@ def rainfall_data_to_db(engine, catchment_polygon: Polygon, path, idf: bool):
         Engine used to connect to the database.
     catchment_polygon : Polygon
         Desired catchment area.
-    path
-         The file path of where the downloaded rainfall data CSV files are stored.
     idf : bool
         Set to False for rainfall depth data, and True for rainfall intensity data.
     """
@@ -233,25 +160,24 @@ def rainfall_data_to_db(engine, catchment_polygon: Polygon, path, idf: bool):
         sites_id_not_in_db = get_sites_id_not_in_db(engine, sites_id_in_catchment, idf)
         # Check if sites_id_not_in_db is not empty
         if sites_id_not_in_db:
-            add_each_site_rainfall_data(engine, sites_id_not_in_db, path, idf)
+            add_each_site_rainfall_data(engine, sites_id_not_in_db, idf)
         else:
             log.info(f"{rain_table_name} data for sites in the requested catchment already available in the database.")
     else:
         # check if sites_id_in_catchment is not empty
         if sites_id_in_catchment:
-            add_each_site_rainfall_data(engine, sites_id_in_catchment, path, idf)
+            add_each_site_rainfall_data(engine, sites_id_in_catchment, idf)
         else:
             log.info("There are no sites within the requested catchment area, select a wider area.")
 
 
 def main():
     catchment_file = pathlib.Path(r"src\dynamic_boundary_conditions\catchment_polygon.shp")
-    file_path_to_store = pathlib.Path(r"U:\Research\FloodRiskResearch\DigitalTwin\hirds_rainfall_data")
     engine = setup_environment.get_database()
     catchment_polygon = hyetograph.catchment_area_geometry_info(catchment_file)
     # Set idf to False for rain depth data and to True for rain intensity data
-    rainfall_data_to_db(engine, catchment_polygon, file_path_to_store, idf=False)
-    rainfall_data_to_db(engine, catchment_polygon, file_path_to_store, idf=True)
+    rainfall_data_to_db(engine, catchment_polygon, idf=False)
+    rainfall_data_to_db(engine, catchment_polygon, idf=True)
 
 
 if __name__ == "__main__":

--- a/src/dynamic_boundary_conditions/hirds_rainfall_data_to_db.py
+++ b/src/dynamic_boundary_conditions/hirds_rainfall_data_to_db.py
@@ -16,9 +16,9 @@ import pathlib
 import logging
 from typing import List, Tuple
 from shapely.geometry import Polygon
-from src.dynamic_boundary_conditions import rainfall_data_from_hirds
 from src.digitaltwin import setup_environment
 from src.dynamic_boundary_conditions import hyetograph
+from src.dynamic_boundary_conditions import rainfall_data_from_hirds
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)

--- a/src/dynamic_boundary_conditions/hyetograph.py
+++ b/src/dynamic_boundary_conditions/hyetograph.py
@@ -5,7 +5,7 @@
 @Author: pkh35
 @Date: 17/01/2022
 @Last modified by: sli229
-@Last modified date: 28/09/2022
+@Last modified date: 4/10/2022
 """
 
 import geopandas as gpd
@@ -35,7 +35,6 @@ def catchment_area_geometry_info(catchment_file_path) -> Polygon:
 
 def main():
     catchment_file = pathlib.Path(r"src\dynamic_boundary_conditions\catchment_polygon.shp")
-    file_path_to_store = pathlib.Path(r"U:\Research\FloodRiskResearch\DigitalTwin\hirds_rainfall_data")
     rcp = 2.6
     time_period = "2031-2050"
     ari = 100
@@ -51,8 +50,8 @@ def main():
     catchment_polygon = catchment_area_geometry_info(catchment_file)
 
     # Set idf to False for rain depth data and to True for rain intensity data
-    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, file_path_to_store, idf=False)
-    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, file_path_to_store, idf=True)
+    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, idf=False)
+    hirds_rainfall_data_to_db.rainfall_data_to_db(engine, catchment_polygon, idf=True)
     rain_depth_in_catchment = hirds_rainfall_data_from_db.rainfall_data_from_db(
         engine, catchment_polygon, rcp, time_period, ari, duration, idf=False)
     print(rain_depth_in_catchment)

--- a/src/dynamic_boundary_conditions/rainfall_data_from_hirds.py
+++ b/src/dynamic_boundary_conditions/rainfall_data_from_hirds.py
@@ -18,7 +18,7 @@ from src.dynamic_boundary_conditions import hirds_rainfall_data_to_db
 
 def get_site_url_key(site_id: str, idf: bool) -> str:
     """
-    Get each rainfall sites' unique url key from the HIRDS website using curl commands.
+    Get the unique URL key of the requested rainfall site from the HIRDS website using curl commands.
 
     Parameters
     ----------

--- a/src/dynamic_boundary_conditions/rainfall_data_from_hirds.py
+++ b/src/dynamic_boundary_conditions/rainfall_data_from_hirds.py
@@ -56,7 +56,7 @@ def get_site_url_key(site_id: str, idf: bool) -> str:
 
 def get_data_from_hirds(site_id: str, idf: bool) -> str:
     """
-    Get rainfall data from the HIRDS website using curl command.
+    Fetch rainfall data for the requested rainfall site from the HIRDS website using curl commands.
 
     Parameters
     ----------

--- a/src/dynamic_boundary_conditions/rainfall_data_from_hirds.py
+++ b/src/dynamic_boundary_conditions/rainfall_data_from_hirds.py
@@ -5,15 +5,15 @@
 @Author: pkh35
 @Date: 20/01/2022
 @Last modified by: sli229
-@Last modified date: 28/09/2022
+@Last modified date: 4/10/2022
 """
 
 import requests
 from requests.structures import CaseInsensitiveDict
 import re
 import pandas as pd
-import pathlib
-from src.dynamic_boundary_conditions import hirds_rainfall_data_to_db
+from typing import List, Tuple
+from io import StringIO
 
 
 def get_site_url_key(site_id: str, idf: bool) -> str:
@@ -86,24 +86,59 @@ def get_data_from_hirds(site_id: str, idf: bool) -> str:
     return site_data
 
 
-def store_data_to_csv(site_id: str, file_path_to_store, idf: bool):
+def get_layout_structure_of_data(site_data: str) -> List[Tuple[int, float, str]]:
     """
-    Store the rainfall data in the form of CSV file in the desired path.
+    Return a list of tuples (skip_rows, rcp, time_period) of the fetched rainfall data's layout structure.
 
     Parameters
     ----------
+    site_data : str
+        Fetched rainfall data text string from the HIRDS website for the requested rainfall site.
+    """
+    skip_rows = []
+    rcp = []
+    time_period = []
+    # Read the site_data text string line by line with a for loop
+    for index, line in enumerate(StringIO(site_data)):
+        # Get lines that contain "(mm) ::" for depth data or "(mm/hr) ::" for intensity data
+        if (line.find("(mm) ::") != -1) or (line.find("(mm/hr) ::") != -1):
+            # Add the row number to skip_rows list
+            skip_rows.append(index + 1)
+            # Add the obtained rcp and time_period values to list
+            rcp_result = re.search(r"(\d*\.\d*)", line)
+            period_result = re.search(r"(\d{4}-\d{4})", line)
+            if rcp_result or period_result is not None:
+                rcp.append(float(rcp_result[0]))
+                time_period.append(period_result[0])
+            else:
+                rcp.append(float('nan'))
+                time_period.append(None)
+    # Merge the three different lists into one list of tuples
+    layout_structure = list(zip(skip_rows, rcp, time_period))
+    return layout_structure
+
+
+def convert_to_tabular_data(site_data: str, site_id: str, skip_rows: int, rcp: float, time_period: str) -> pd.DataFrame:
+    """
+    Return the requested rainfall site data in Pandas DataFrame format.
+
+    Parameters
+    ----------
+    site_data : str
+        Fetched rainfall data text string from the HIRDS website for the requested rainfall site.
     site_id : str
         HIRDS rainfall site id.
-    file_path_to_store
-        The file path used to store the downloaded rainfall data CSV file.
-    idf : bool
-        Set to False for rainfall depth data, and True for rainfall intensity data.
+    skip_rows : int
+        Number of lines to skip at the start of the fetched rainfall site_data.
+    rcp : float
+        There are four different representative concentration pathways (RCPs), and abbreviated as RCP2.6, RCP4.5,
+        RCP6.0 and RCP8.5, in order of increasing radiative forcing by greenhouse gases.
+    time_period : str
+        Rainfall estimates for two future time periods (e.g. 2031-2050 or 2081-2100) for four RCPs.
     """
-    if not pathlib.Path.exists(file_path_to_store):
-        file_path_to_store.mkdir(parents=True, exist_ok=True)
-
-    rain_table_name = hirds_rainfall_data_to_db.db_rain_table_name(idf)
-    filename = pathlib.Path(f"{site_id}_{rain_table_name}.csv")
-    site_data = get_data_from_hirds(site_id, idf)
-    with open(file_path_to_store / filename, "w") as file:
-        file.write(site_data)
+    rainfall_data = pd.read_csv(StringIO(site_data), skiprows=skip_rows, nrows=12)
+    rainfall_data.insert(0, "site_id", site_id)
+    rainfall_data.insert(1, "rcp", rcp)
+    rainfall_data.insert(2, "time_period", time_period)
+    rainfall_data.columns = rainfall_data.columns.str.lower()
+    return rainfall_data

--- a/src/dynamic_boundary_conditions/rainfall_data_from_hirds.py
+++ b/src/dynamic_boundary_conditions/rainfall_data_from_hirds.py
@@ -107,7 +107,7 @@ def get_layout_structure_of_data(site_data: str) -> List[Tuple[int, float, str]]
             # Add the obtained rcp and time_period values to list
             rcp_result = re.search(r"(\d*\.\d*)", line)
             period_result = re.search(r"(\d{4}-\d{4})", line)
-            if rcp_result or period_result is not None:
+            if rcp_result is not None or period_result is not None:
                 rcp.append(float(rcp_result[0]))
                 time_period.append(period_result[0])
             else:


### PR DESCRIPTION
DESCRIPTION OF PR:
Currently rainfall data is fetched from the web, saved to CSV, read from CSV, and then saved to the database.
I have checked with Matt, we can remove the redundant CSV saving and just save directly to the database.

Fixes: #57 

## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [ ] Test locally and ensure tests are passing
- [x] Update documentation
  - [x] Readme
  - [x] Docstrings
  - [x] Comments
  - [ ] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
