### PR TITLE
Update test_setup_environment.py to pass on local machines and not run in GitHub Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,6 +72,8 @@ jobs:
           echo $ENV_BASE64 | base64 -d > .env
 
       - name: Run tests with pytest
+        env:
+          TEST_DATABASE_INTEGRATION: "false"
         run: |
           pytest
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,14 +51,6 @@ jobs:
         with:
           lfs: true
 
-      - name: Cache conda
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-conda-env
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.cache-name }}-${{ hashFiles('environment.yml') }}
-
       - name: Install package dependencies
         uses: mamba-org/setup-micromamba@v1
         with:

--- a/tests/test_digitaltwin/test_setup_environment.py
+++ b/tests/test_digitaltwin/test_setup_environment.py
@@ -1,6 +1,8 @@
 import os
+import platform
 import unittest
 
+import pytest
 from sqlalchemy.exc import OperationalError
 
 from src.digitaltwin import setup_environment
@@ -8,21 +10,29 @@ from src.digitaltwin import setup_environment
 
 class SetupEnvironmentTest(unittest.TestCase):
 
-    @unittest.skip("Skipping until we work on https://github.com/GeospatialResearch/Digital-Twins/issues/23")
+    @pytest.mark.skipif(
+        platform.system() != "Windows",
+        reason="This test only runs on local dev machines with a database running. "
+               "It is not set up to integrate into a test suite.")
     def test_connection(self):
         """Check a connection to the database can be made with the default parameters of get_connection_from_profile"""
         engine = setup_environment.get_connection_from_profile()
         connection = engine.connect()
         self.assertFalse(connection.closed,
-                         msg="The connection to the database failed")  # Check that the connection is open
+                         msg="The connection to the database failed and is needed for these tests.")
 
-    @unittest.skip("Skipping until we work on https://github.com/GeospatialResearch/Digital-Twins/issues/23")
+    @pytest.mark.skipif(
+        platform.system() != "Windows",
+        reason="This test only runs on local dev machines with a database running. "
+               "It is not set up to integrate into a test suite.")
     def test_incorrect_password(self):
         """Ensure that when a bad password is given to the database, the connection fails and an exception is raised"""
         # Override the variables supplied by the .env file with an incorrect password
+        self.test_connection()  # This test case requires an active connection to trust the result.
         os.environ["POSTGRES_PASSWORD"] = "incorrect_password"
         with self.assertRaises(OperationalError,
-                               msg="get_connection_from_profile should raise an OperationalError if the password supplied is incorrect"):
+                               msg="get_connection_from_profile should raise an OperationalError"
+                                   " if the password supplied is incorrect"):
             setup_environment.get_connection_from_profile()
 
 

--- a/tests/test_digitaltwin/test_setup_environment.py
+++ b/tests/test_digitaltwin/test_setup_environment.py
@@ -1,34 +1,44 @@
 import os
-import platform
 import unittest
 
 import pytest
 from sqlalchemy.exc import OperationalError
 
+from src import config
 from src.digitaltwin import setup_environment
 
 
 class SetupEnvironmentTest(unittest.TestCase):
 
-    @pytest.mark.skipif(
-        platform.system() != "Windows",
-        reason="This test only runs on local dev machines with a database running. "
-               "It is not set up to integrate into a test suite.")
+    @classmethod
+    def setUpClass(cls):
+        """Set up arguments used for testing."""
+        # flag for checking if tests requiring database to be active should run
+        cls.run_database_integration_tests = config.get_env_variable("TEST_DATABASE_INTEGRATION",
+                                                                     default=True,
+                                                                     allow_empty=True,
+                                                                     cast_to=bool
+                                                                     )
+        cls.DATABASE_SKIP_REASON = """TEST_DATABASE_INTEGRATION env var is not True, so the test is skipped.
+            This is intentional at all times on the GitHub Actions."""
+
     def test_connection(self):
         """Check a connection to the database can be made with the default parameters of get_connection_from_profile"""
+        # Skip this if database tests are not intended to be run in this environment
+        if not self.run_database_integration_tests:
+            pytest.skip(self.DATABASE_SKIP_REASON)
         engine = setup_environment.get_connection_from_profile()
         connection = engine.connect()
         self.assertFalse(connection.closed,
                          msg="The connection to the database failed and is needed for these tests.")
 
-    @pytest.mark.skipif(
-        platform.system() != "Windows",
-        reason="This test only runs on local dev machines with a database running. "
-               "It is not set up to integrate into a test suite.")
     def test_incorrect_password(self):
         """Ensure that when a bad password is given to the database, the connection fails and an exception is raised"""
-        # Override the variables supplied by the .env file with an incorrect password
+        # Skip this if database tests are not intended to be run in this environment
+        if not self.run_database_integration_tests:
+            pytest.skip(self.DATABASE_SKIP_REASON)
         self.test_connection()  # This test case requires an active connection to trust the result.
+        # Override the variables supplied by the .env file with an incorrect password
         os.environ["POSTGRES_PASSWORD"] = "incorrect_password"
         with self.assertRaises(OperationalError,
                                msg="get_connection_from_profile should raise an OperationalError"


### PR DESCRIPTION
To test enter the following commands from project root:
1. Start database:
 `docker-compose up -d db_postgres`
3. Run test_setup_environment.py:   
`python -m tests.test_setup_environment.test_setup_environment`
4. Run all tests: 
`pytest`

DESCRIPTION OF PR:

This test was originally written to teach some testing skills and as an incentive to fix some errors.
The errors were fixed in #81 but the tests still needed to pass.

Because these tests integrate with the database it does not match with our current testing platform.
However, they can run locally.

I have decided to allow these tests to run locally on Windows but not on docker or in the automated test runner. Please give me your thoughts on this.

## Developer Checklist
- [X] Make code change
- [X] Update tests
  - [X] Update / create new tests
  - [X] Ensure these tests have the expected behaviour
  - [X] Test locally and ensure tests are passing
- [X] Update documentation
~~- [ ] Readme~~
  - [X] Docstrings
  - [X] Comments
~~- [ ] Wiki~~

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
