### PR TITLE
bg flood model remove default values for `output_timestep` and `end_time`

### DIFF
--- a/src/flood_model/bg_flood_model.py
+++ b/src/flood_model/bg_flood_model.py
@@ -288,8 +288,8 @@ def prepare_bg_flood_model_inputs(
         model_output_path: pathlib.Path,
         hydro_dem_path: pathlib.Path,
         resolution: Union[int, float],
-        output_timestep: Union[int, float] = 0,
-        end_time: Union[int, float] = 0,
+        output_timestep: Union[int, float],
+        end_time: Union[int, float],
         mask: Union[int, float] = 9999,
         gpu_device: int = 0,
         small_nc: int = 0) -> None:
@@ -358,8 +358,8 @@ def run_bg_flood_model(
         engine: Engine,
         catchment_area: gpd.GeoDataFrame,
         model_output_path: pathlib.Path,
-        output_timestep: Union[int, float] = 0,
-        end_time: Union[int, float] = 0,
+        output_timestep: Union[int, float],
+        end_time: Union[int, float],
         resolution: Optional[Union[int, float]] = None,
         mask: Union[int, float] = 9999,
         gpu_device: int = 0,
@@ -376,9 +376,9 @@ def run_bg_flood_model(
     model_output_path : pathlib.Path
         The new file path for saving the BG Flood model output with the current timestamp included in the filename.
     output_timestep : Union[int, float]
-        Time step between model outputs in seconds. Default value is 0.0 (no output generated).
+        Time step between model outputs in seconds. If the value is set to 0 then no output is generated.
     end_time : Union[int, float]
-        Time in seconds when the model stops. Default value is 0.0 (model initializes but does not run).
+        Time in seconds when the model stops. If the value is set to 0 then the model initializes but does not run.
     resolution : Optional[Union[int, float]] = None
         The grid resolution in meters for metric grids, representing the size of each grid cell.
         If not provided (default is None), the resolution of the Hydrologically conditioned DEM will be used as
@@ -431,8 +431,8 @@ def run_bg_flood_model(
 
 def main(
         selected_polygon_gdf: gpd.GeoDataFrame,
-        output_timestep: Union[int, float] = 0,
-        end_time: Union[int, float] = 0,
+        output_timestep: Union[int, float],
+        end_time: Union[int, float],
         resolution: Optional[Union[int, float]] = None,
         mask: Union[int, float] = 9999,
         gpu_device: int = 0,
@@ -446,10 +446,10 @@ def main(
     ----------
     selected_polygon_gdf : gpd.GeoDataFrame
         A GeoDataFrame representing the selected polygon, i.e., the catchment area.
-    output_timestep : Union[int, float] = 0
-        Time step between model outputs in seconds. Default value is 0.0 (no output generated).
-    end_time : Union[int, float] = 0
-        Time in seconds when the model stops. Default value is 0.0 (model initializes but does not run).
+    output_timestep : Union[int, float]
+        Time step between model outputs in seconds. If the value is set to 0 then no output is generated.
+    end_time : Union[int, float]
+        Time in seconds when the model stops. If the value is set to 0 then the model initializes but does not run.
     resolution : Optional[Union[int, float]] = None
         The grid resolution in meters for metric grids, representing the size of each grid cell.
         If not provided (default is None), the resolution of the Hydrologically conditioned DEM will be used as


### PR DESCRIPTION
DESCRIPTION OF PR:

## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [ ] Test locally and ensure tests are passing
- [ ] Update documentation
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
