### PR TITLE
Switch to a newzealidar version that works on both Windows and Linux

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -35,6 +35,6 @@ dependencies:
     - geoapis==0.3.2
     - celery==5.2.7
     - gunicorn==20.1.0
-    - git+https://github.com/LukeParky/NewZeaLiDAR.git@v0.2 # v0.1 for Windows, v0.2 for Linux
+    - git+https://github.com/LukeParky/NewZeaLiDAR.git@v0.3
 
 prefix: 


### PR DESCRIPTION
DESCRIPTION OF PR:

Closes #139 
Switches to a new NewZealidar version that is based on the merge of v0.1 and v0.2 so that they can run on Windows and Linux. This version also has the NewZealidar version locked down

## Developer Checklist
- [x] Make code change
- [x] Test on Linux
- [x] Test on Windows
- [x] Update documentation
  - [x] Readme
  - [x] Docstrings
  - [x] Comments
  - [x] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
