### PR TITLE
Encapsulate newzealidar functions

### DIFF
--- a/src/flood_model/process_hydro_dem.py
+++ b/src/flood_model/process_hydro_dem.py
@@ -13,19 +13,18 @@ log = logging.getLogger(__name__)
 
 def ensure_lidar_datasets_initialised() -> None:
     """
-    Checks if LiDAR datasets table is initialised.
+    Check if LiDAR datasets table is initialised.
     This table holds URLs to data sources for LiDAR.
     If it is not initialised, then it initialises it by web-scraping OpenTopography which takes a long time.
 
     Returns
     -------
     None
-        This function does not return anything
+        This function does not return any value.
     """
     # Connect to database
     engine = setup_environment.get_connection_from_profile()
     # Check if datasets table initialised
-
     if not tables.check_table_exists(engine, "dataset"):
         # If it is not initialised, then initialise it
         log.info("dataset table does not exist, initialising LiDAR dataset information.")
@@ -55,7 +54,7 @@ def process_dem(selected_polygon_gdf: gpd.GeoDataFrame) -> None:
     Returns
     -------
     None
-        This function does not return anything
+        This function does not return any value.
     """
     log.info("Processing LiDAR data into hydrologically conditioned DEM for area of interest.")
     newzealidar.process.main(selected_polygon_gdf)
@@ -64,7 +63,7 @@ def process_dem(selected_polygon_gdf: gpd.GeoDataFrame) -> None:
 def refresh_lidar_datasets() -> None:
     """
     Web-scrapes OpenTopography metadata to create the datasets table containing links to LiDAR data sources.
-    Takes a long time to run but needs to be run periodically so that the datasets are up to date
+    Takes a long time to run but needs to be run periodically so that the datasets are up to date.
 
     Returns
     -------

--- a/src/flood_model/process_hydro_dem.py
+++ b/src/flood_model/process_hydro_dem.py
@@ -1,6 +1,4 @@
-"""
-This script fetches LiDAR terrain data for a region of interest and creates a hydrologically-conditioned DEM.
-"""
+"""This script fetches LiDAR terrain data for a region of interest and creates a hydrologically-conditioned DEM."""
 
 import json
 import logging

--- a/src/flood_model/process_hydro_dem.py
+++ b/src/flood_model/process_hydro_dem.py
@@ -1,3 +1,7 @@
+"""
+This script fetches LiDAR terrain data for a region of interest and creates a hydrologically-conditioned DEM.
+"""
+
 import json
 import logging
 
@@ -44,7 +48,7 @@ def ensure_lidar_datasets_initialised() -> None:
 
 def process_dem(selected_polygon_gdf: gpd.GeoDataFrame) -> None:
     """
-    Task to ensure hydrologically-conditioned DEM is processed for the given area and added to the database.
+    Ensures hydrologically-conditioned DEM is processed for the given area and added to the database.
 
     Parameters
     ----------
@@ -68,7 +72,7 @@ def refresh_lidar_datasets() -> None:
     Returns
     -------
     None
-        This function does not return anything
+        This function does not return any value.
     """
     newzealidar.datasets.main()
 
@@ -77,7 +81,7 @@ def main(
         selected_polygon_gdf: gpd.GeoDataFrame,
         log_level: LogLevel = LogLevel.DEBUG) -> None:
     """
-    Fetch and store rainfall data in the database, and generate the requested rainfall model input for BG-Flood.
+    Retrieves LiDAR data for the selected polygon and processes it into a hydrologically-conditioned DEM.
 
     Parameters
     ----------

--- a/src/flood_model/process_hydro_dem.py
+++ b/src/flood_model/process_hydro_dem.py
@@ -1,0 +1,105 @@
+import json
+import logging
+
+import geopandas as gpd
+import newzealidar.datasets
+import newzealidar.process
+
+from src.digitaltwin import setup_environment, tables
+from src.digitaltwin.utils import LogLevel, setup_logging
+
+log = logging.getLogger(__name__)
+
+
+def ensure_lidar_datasets_initialised() -> None:
+    """
+    Checks if LiDAR datasets table is initialised.
+    This table holds URLs to data sources for LiDAR.
+    If it is not initialised, then it initialises it by web-scraping OpenTopography which takes a long time.
+
+    Returns
+    -------
+    None
+        This function does not return anything
+    """
+    # Connect to database
+    engine = setup_environment.get_connection_from_profile()
+    # Check if datasets table initialised
+
+    if not tables.check_table_exists(engine, "dataset"):
+        # If it is not initialised, then initialise it
+        log.info("dataset table does not exist, initialising LiDAR dataset information.")
+        newzealidar.datasets.main()
+    # Check that datasets_mapping is in the instructions.json file
+    instructions_file_name = "instructions.json"
+    with open(instructions_file_name, "r") as instructions_file:
+        # Load content from the file
+        instructions = json.load(instructions_file)["instructions"]
+    dataset_mapping = instructions.get("dataset_mapping")
+    # If the dataset_mapping does not exist on the instruction file then read it from the database
+    if dataset_mapping is None:
+        # Add dataset_mapping to instructions file, reading from database
+        log.debug("instructions.json missing LiDAR dataset_mapping, filling from database.")
+        newzealidar.utils.map_dataset_name(engine, instructions_file_name)
+
+
+def process_dem(selected_polygon_gdf: gpd.GeoDataFrame) -> None:
+    """
+    Task to ensure hydrologically-conditioned DEM is processed for the given area and added to the database.
+
+    Parameters
+    ----------
+    selected_polygon_gdf : gpd.GeoDataFrame
+        The polygon defining the selected area to process the DEM for.
+
+    Returns
+    -------
+    None
+        This function does not return anything
+    """
+    log.info("Processing LiDAR data into hydrologically conditioned DEM for area of interest.")
+    newzealidar.process.main(selected_polygon_gdf)
+
+
+def refresh_lidar_datasets() -> None:
+    """
+    Web-scrapes OpenTopography metadata to create the datasets table containing links to LiDAR data sources.
+    Takes a long time to run but needs to be run periodically so that the datasets are up to date
+
+    Returns
+    -------
+    None
+        This function does not return anything
+    """
+    newzealidar.datasets.main()
+
+
+def main(
+        selected_polygon_gdf: gpd.GeoDataFrame,
+        log_level: LogLevel = LogLevel.DEBUG) -> None:
+    """
+    Fetch and store rainfall data in the database, and generate the requested rainfall model input for BG-Flood.
+
+    Parameters
+    ----------
+    selected_polygon_gdf : gpd.GeoDataFrame
+        A GeoDataFrame representing the selected polygon, i.e., the catchment area.
+    log_level : LogLevel = LogLevel.DEBUG
+        The log level to set for the root logger. Defaults to LogLevel.DEBUG.
+        The available logging levels and their corresponding numeric values are:
+        - LogLevel.CRITICAL (50)
+        - LogLevel.ERROR (40)
+        - LogLevel.WARNING (30)
+        - LogLevel.INFO (20)
+        - LogLevel.DEBUG (10)
+        - LogLevel.NOTSET (0)
+
+    Returns
+    -------
+    None
+        This function does not return any value.
+    """
+    # Set up logging with the specified log level
+    setup_logging(log_level)
+    ensure_lidar_datasets_initialised()
+    process_dem(selected_polygon_gdf)

--- a/src/run_all.py
+++ b/src/run_all.py
@@ -8,7 +8,6 @@ from types import ModuleType
 from typing import Dict, Union
 
 import geopandas as gpd
-from newzealidar import datasets, process
 
 from src.digitaltwin import retrieve_static_boundaries
 from src.digitaltwin.utils import LogLevel
@@ -17,7 +16,7 @@ from src.dynamic_boundary_conditions.rainfall.rainfall_enum import RainInputType
 from src.dynamic_boundary_conditions.river import main_river
 from src.dynamic_boundary_conditions.river.river_enum import BoundType
 from src.dynamic_boundary_conditions.tide import main_tide_slr
-from src.flood_model import bg_flood_model
+from src.flood_model import bg_flood_model, process_hydro_dem
 
 
 def main(
@@ -57,10 +56,7 @@ DEFAULT_MODULES_TO_PARAMETERS = {
     retrieve_static_boundaries: {
         "log_level": LogLevel.INFO
     },
-    datasets: {
-        "log_level": LogLevel.INFO  # only need to run it one time to initiate db.dataset table
-    },
-    process: {
+    process_hydro_dem: {
         "log_level": LogLevel.INFO
     },
     main_rainfall: {

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -2,7 +2,6 @@
 Runs backend tasks using Celery. Allowing for multiple long-running tasks to complete in the background.
 Allows the frontend to send tasks and retrieve status later.
 """
-import json
 import logging
 import traceback
 from typing import List, NamedTuple
@@ -15,12 +14,12 @@ from celery import Celery, states, result
 from pyproj import Transformer
 
 from src.config import get_env_variable
-from src.digitaltwin import retrieve_static_boundaries, setup_environment, tables
+from src.digitaltwin import retrieve_static_boundaries, setup_environment
 from src.digitaltwin.utils import setup_logging
 from src.dynamic_boundary_conditions.rainfall import main_rainfall
 from src.dynamic_boundary_conditions.river import main_river
 from src.dynamic_boundary_conditions.tide import main_tide_slr
-from src.flood_model import bg_flood_model
+from src.flood_model import bg_flood_model, process_hydro_dem
 from src.run_all import DEFAULT_MODULES_TO_PARAMETERS
 
 # Setup celery backend task management
@@ -74,7 +73,6 @@ def create_model_for_area(selected_polygon_wkt: str, scenario_options: dict) -> 
         The task result for the long-running group of tasks. The task ID represents the final task in the group.
     """
     return (
-            ensure_lidar_datasets_initialised.si() |
             add_base_data_to_db.si(selected_polygon_wkt) |
             process_dem.si(selected_polygon_wkt) |
             generate_rainfall_inputs.si(selected_polygon_wkt) |
@@ -82,36 +80,6 @@ def create_model_for_area(selected_polygon_wkt: str, scenario_options: dict) -> 
             generate_river_inputs.si(selected_polygon_wkt) |
             run_flood_model.si(selected_polygon_wkt)
     )()
-
-
-@app.task(base=OnFailureStateTask)
-def ensure_lidar_datasets_initialised() -> None:
-    """
-    Task checks if LiDAR datasets table is initialised.
-    This table holds URLs to data sources for LiDAR.
-    If it is not initialised, then it initialises it by web-scraping OpenTopography which takes a long time.
-
-    Returns
-    -------
-    None
-        This task does not return anything
-    """
-    # Connect to database
-    engine = setup_environment.get_connection_from_profile()
-    # Check if datasets table initialised
-    if not tables.check_table_exists(engine, "dataset"):
-        # If it is not initialised, then initialise it
-        newzealidar.datasets.main()
-    # Check that datasets_mapping is in the instructions.json file
-    instructions_file_name = "instructions.json"
-    with open(instructions_file_name, "r") as instructions_file:
-        # Load content from the file
-        instructions = json.load(instructions_file)["instructions"]
-    dataset_mapping = instructions.get("dataset_mapping")
-    # If the dataset_mapping does not exist on the instruction file then read it from the database
-    if dataset_mapping is None:
-        # Add dataset_mapping to instructions file, reading from database
-        newzealidar.utils.map_dataset_name(engine, instructions_file_name)
 
 
 @app.task(base=OnFailureStateTask)
@@ -149,9 +117,9 @@ def process_dem(selected_polygon_wkt: str):
     None
         This task does not return anything
     """
-    parameters = DEFAULT_MODULES_TO_PARAMETERS[newzealidar.process]
+    parameters = DEFAULT_MODULES_TO_PARAMETERS[process_hydro_dem]
     selected_polygon = wkt_to_gdf(selected_polygon_wkt)
-    newzealidar.process.main(selected_polygon, **parameters)
+    process_hydro_dem.main(selected_polygon, **parameters)
 
 
 @app.task(base=OnFailureStateTask)

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -7,7 +7,6 @@ import traceback
 from typing import List, NamedTuple
 
 import geopandas as gpd
-import newzealidar
 import shapely
 import xarray
 from celery import Celery, states, result
@@ -217,7 +216,7 @@ def refresh_lidar_datasets() -> None:
     None
         This task does not return anything
     """
-    newzealidar.datasets.main()
+    process_hydro_dem.refresh_lidar_datasets()
 
 
 def wkt_to_gdf(wkt: str) -> gpd.GeoDataFrame:


### PR DESCRIPTION
This allows for runtime checks if the datasets table exists when running the `run_all.py` script.
This reduces coupling and allows for a better developer experience because we don't have to comment out the `datasets` lines to prevent `datasets` from running.
It also reduces the complexity of both `run_all.py` and `tasks.py`.

Closes #179 

DESCRIPTION OF PR:

## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [x] Test locally and ensure tests are passing
- [ ] Update documentation
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
