### PR TITLE
Change ownership of automated commits to GRI Admin

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -27,8 +27,8 @@ jobs:
         cp -a _build/. ../docs
     - name: Commit doc changes
       run: |
-        git config --global user.name 'Luke Parkinson'
-        git config --global user.email 'luke.parkinson@users.noreply.github.com'
+        git config --global user.name 'GRI Admin'
+        git config --global user.email '175378150+GRI-Admin@users.noreply.github.com'
         git add ../docs/*
         : # Commit changes if there are any
         git diff --cached --exit-code || git commit -m "Automated update - Sphinx documentation"


### PR DESCRIPTION
Closes #184 

Because of branch protection rules, github actions can not push to protected branches.
Originally we got around this by using an admin as the workflow runner, but this means all admins are allowed to push to protected branches.

I have removed all standard users from the admin role and created a new @GRI-Admin service user that will activate the workflow instead.

The workflow needs to be modified to use this user.