### PR TITLE
165 heartbeat logs are getting through to docker services

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,7 @@ ENTRYPOINT source /venv/bin/activate && \
            health-checker --listener 0.0.0.0:5001 --log-level error --script-timeout 10 \
              --script "celery -A src.tasks inspect ping"  & \
            source /venv/bin/activate && \
-           celery -A src.tasks worker -P threads --loglevel=INFO
+           celery -A src.tasks worker --pool=solo --loglevel=INFO
 
 FROM docker.osgeo.org/geoserver:2.21.2 as geoserver
 


### PR DESCRIPTION
DESCRIPTION OF PR: The error was due to using `-P threads` in `celery -A src.tasks worker -P threads --loglevel=INFO` in  `Dockerfile`. We changed it to `celery -A src.tasks worker --pool=solo --loglevel=INFO`.


## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [ ] Test locally and ensure tests are passing
- [ ] Update documentation
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki

## Reviewer Checklist
- [x] Check new code for code smells
- [ ] Check new tests
  - [x] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [x] Check if documentation needs updating
  - [x] Readme
  - [x] Docstrings
  - [x] Comments
  - [ ] Wiki
