### PR TITLE
24-mitigate-sql-injection-risk-by-using-sql-prepared-statements-or-similar-rather-than-string-formatting

### DIFF
--- a/src/digitaltwin/data_to_db.py
+++ b/src/digitaltwin/data_to_db.py
@@ -340,16 +340,16 @@ def process_existing_non_nz_geospatial_layers(
         # Get IDs from the vector data that are not in the database
         ids_not_in_db = get_vector_data_id_not_in_db(
             engine, vector_data, table_name, unique_column_name, area_of_interest)
-    # Check if there are IDs not in the database
-    if ids_not_in_db:
-        # Get vector data that contains only the IDs not present in the database
-        vector_data_not_in_db = vector_data[vector_data[unique_column_name].isin(ids_not_in_db)]
-        # Insert vector data into the database
-        log.info(
-            f"Adding new '{table_name}' data ({data_provider} {layer_id}) for the catchment area to the database.")
-        vector_data_not_in_db.to_postgis(table_name, engine, index=False, if_exists="append")
-    else:
-        log.info(f"'{table_name}' data for the requested catchment area is already in the database.")
+        # Check if there are IDs not in the database
+        if ids_not_in_db:
+            # Get vector data that contains only the IDs not present in the database
+            vector_data_not_in_db = vector_data[vector_data[unique_column_name].isin(ids_not_in_db)]
+            # Insert vector data into the database
+            log.info(
+                f"Adding new '{table_name}' data ({data_provider} {layer_id}) for the catchment area to the database.")
+            vector_data_not_in_db.to_postgis(table_name, engine, index=False, if_exists="append")
+        else:
+            log.info(f"'{table_name}' data for the requested catchment area is already in the database.")
 
 
 def non_nz_geospatial_layers_data_to_db(

--- a/src/dynamic_boundary_conditions/rainfall/thiessen_polygons.py
+++ b/src/dynamic_boundary_conditions/rainfall/thiessen_polygons.py
@@ -10,6 +10,7 @@ import geopandas as gpd
 import pandas as pd
 from geovoronoi import voronoi_regions_from_coords, points_to_coords
 from sqlalchemy.engine import Engine
+from sqlalchemy.sql import text
 
 from src.digitaltwin import tables
 from src.digitaltwin.utils import get_nz_boundary
@@ -37,11 +38,12 @@ def get_sites_within_aoi(engine: Engine, area_of_interest: gpd.GeoDataFrame) -> 
     # Extract the geometry of the area of interest
     aoi_polygon = area_of_interest["geometry"].iloc[0]
     # Construct the query to fetch rainfall sites within the area of interest
-    query = f"""
+    command_text = f"""
     SELECT *
     FROM rainfall_sites AS rs
-    WHERE ST_Within(rs.geometry, ST_GeomFromText('{aoi_polygon}', 4326));
+    WHERE ST_Within(rs.geometry, ST_GeomFromText(:aoi_polygon, 4326));
     """
+    query = text(command_text).bindparams(aoi_polygon=aoi_polygon)
     # Execute the query and retrieve the results as a GeoDataFrame
     sites_in_aoi = gpd.GeoDataFrame.from_postgis(query, engine, geom_col="geometry", crs=4326)
     # Reset the index
@@ -151,13 +153,20 @@ def thiessen_polygons_from_db(engine: Engine, catchment_area: gpd.GeoDataFrame) 
     # Extract the geometry of the catchment area
     catchment_polygon = catchment_area["geometry"].iloc[0]
     # Construct the query to get rainfall sites coverage areas (Thiessen polygons)
-    query = f"""
+    command_text = """
     SELECT *
     FROM rainfall_sites_voronoi AS rsv
-    WHERE ST_Intersects(rsv.geometry, ST_GeomFromText('{catchment_polygon}', 4326));
+    WHERE ST_Intersects(rsv.geometry, ST_GeomFromText(:catchment_polygon, 4326));
     """
+    query = text(command_text).bindparams(
+        catchment_polygon=str(catchment_polygon)
+    )
     # Retrieve the data from the database
-    sites_in_catchment = gpd.GeoDataFrame.from_postgis(query, engine, geom_col="geometry", crs=4326)
+    sites_in_catchment = gpd.GeoDataFrame.from_postgis(
+        query,
+        engine,
+        geom_col="geometry", crs=4326
+    )
     # Reset the index
     sites_in_catchment.reset_index(drop=True, inplace=True)
     return sites_in_catchment

--- a/src/dynamic_boundary_conditions/rainfall/thiessen_polygons.py
+++ b/src/dynamic_boundary_conditions/rainfall/thiessen_polygons.py
@@ -38,12 +38,12 @@ def get_sites_within_aoi(engine: Engine, area_of_interest: gpd.GeoDataFrame) -> 
     # Extract the geometry of the area of interest
     aoi_polygon = area_of_interest["geometry"].iloc[0]
     # Construct the query to fetch rainfall sites within the area of interest
-    command_text = f"""
+    command_text = """
     SELECT *
     FROM rainfall_sites AS rs
     WHERE ST_Within(rs.geometry, ST_GeomFromText(:aoi_polygon, 4326));
     """
-    query = text(command_text).bindparams(aoi_polygon=aoi_polygon)
+    query = text(command_text).bindparams(aoi_polygon=str(aoi_polygon))
     # Execute the query and retrieve the results as a GeoDataFrame
     sites_in_aoi = gpd.GeoDataFrame.from_postgis(query, engine, geom_col="geometry", crs=4326)
     # Reset the index

--- a/src/dynamic_boundary_conditions/river/river_data_to_from_db.py
+++ b/src/dynamic_boundary_conditions/river/river_data_to_from_db.py
@@ -9,6 +9,7 @@ import logging
 import geopandas as gpd
 import pandas as pd
 from sqlalchemy.engine import Engine
+from sqlalchemy.sql import text
 
 from src.digitaltwin.tables import check_table_exists
 from src.dynamic_boundary_conditions.river import river_data_from_niwa
@@ -70,11 +71,14 @@ def get_sdc_data_from_db(engine: Engine, catchment_area: gpd.GeoDataFrame) -> gp
     # Extract the geometry of the catchment area
     catchment_polygon = catchment_area["geometry"][0]
     # Query to retrieve sea-draining catchments that intersect with the catchment polygon
-    sea_drain_query = f"""
+    command_text = """
     SELECT *
     FROM sea_draining_catchments AS sdc
-    WHERE ST_Intersects(sdc.geometry, ST_GeomFromText('{catchment_polygon}', 2193));
+    WHERE ST_Intersects(sdc.geometry, ST_GeomFromText(:catchment_polygon, 2193));
     """
+    sea_drain_query = text(command_text).bindparams(
+        catchment_polygon=str(catchment_polygon)
+    )
     # Execute the query and create a GeoDataFrame from the result
     sdc_data = gpd.GeoDataFrame.from_postgis(sea_drain_query, engine, geom_col="geometry")
     return sdc_data
@@ -114,11 +118,14 @@ def get_rec_data_with_sdc_from_db(
     # Combine the sea-draining catchment area with the input catchment area to create a final unified polygon
     combined_polygon = pd.concat([sdc_area, catchment_area]).unary_union
     # Query to retrieve REC data that intersects with the combined polygon
-    rec_query = f"""
+    command_text = """
     SELECT *
     FROM rec_data AS rec
-    WHERE ST_Intersects(rec.geometry, ST_GeomFromText('{combined_polygon}', 2193));
+    WHERE ST_Intersects(rec.geometry, ST_GeomFromText(:combined_polygon, 2193));
     """
+    rec_query = text(command_text).bindparams(
+        combined_polygon=str(combined_polygon)
+    )
     # Execute the query and retrieve the REC data from the database
     rec_data = gpd.GeoDataFrame.from_postgis(rec_query, engine, geom_col="geometry")
     # Determine the sea-draining catchment for each REC geometry (using the 'within' predicate)

--- a/src/dynamic_boundary_conditions/river/river_network_to_from_db.py
+++ b/src/dynamic_boundary_conditions/river/river_network_to_from_db.py
@@ -18,6 +18,8 @@ import numpy as np
 import shapely.wkt
 from sqlalchemy import select, func
 from sqlalchemy.engine import Engine
+from sqlalchemy.sql import text
+
 
 from src.config import get_env_variable
 from src.digitaltwin.tables import (
@@ -234,11 +236,14 @@ def get_existing_network_metadata_from_db(engine: Engine, catchment_area: gpd.Ge
     catchment_polygon = catchment_area["geometry"].iloc[0]
     catchment_polygon_wkt = shapely.wkt.dumps(catchment_polygon, rounding_precision=6)
     # Query the REC Network Output table to find existing REC river network metadata for the catchment area
-    query = f"""
+    command_text = f"""
     SELECT *
     FROM {RiverNetwork.__tablename__}
-    WHERE ST_Equals(geometry, ST_GeomFromText('{catchment_polygon_wkt}', 2193));
+    WHERE ST_Equals(geometry, ST_GeomFromText(:catchment_polygon_wkt, 2193));
     """
+    query = text(command_text).bindparams(
+        catchment_polygon_wkt=str(catchment_polygon_wkt)
+    )
     # Fetch the query result as a GeoPandas DataFrame
     existing_network_meta = gpd.GeoDataFrame.from_postgis(query, engine, geom_col="geometry")
     return existing_network_meta
@@ -268,11 +273,14 @@ def get_existing_network(engine: Engine, existing_network_meta: gpd.GeoDataFrame
     # Extract the REC river network ID from the provided metadata
     rec_network_id = existing_network_series["rec_network_id"]
     # Construct a query to retrieve exclusion data for the existing REC river network
-    query = f"""
+    command_text = f"""
     SELECT *
     FROM {RiverNetworkExclusions.__tablename__}
-    WHERE rec_network_id = {rec_network_id};
+    WHERE rec_network_id=:rec_network_id;
     """
+    query = text(command_text).bindparams(
+        rec_network_id=str(rec_network_id)
+    )
     # Query the database to retrieve exclusion data for the existing REC river network
     rec_network_exclusions = gpd.GeoDataFrame.from_postgis(query, engine, geom_col="geometry")
     # Group exclusion data by the cause of exclusion

--- a/src/dynamic_boundary_conditions/tide/sea_level_rise_data.py
+++ b/src/dynamic_boundary_conditions/tide/sea_level_rise_data.py
@@ -19,6 +19,7 @@ from selenium import webdriver
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from sqlalchemy.engine import Engine
+from sqlalchemy.sql import text
 
 from src import config
 from src.digitaltwin import tables
@@ -228,17 +229,20 @@ def get_closest_slr_data(engine: Engine, single_query_loc: pd.Series) -> gpd.Geo
     # relevant data, which includes the calculated distance. By matching the closest location's 'siteid' from the
     # inner subquery with the corresponding data in the sea_level_rise table using the JOIN clause, the outer query
     # obtains the sea level rise data for the closest location, along with its associated distance value.
-    query = f"""
+    command_text = """
     SELECT slr.*, distances.distance
     FROM sea_level_rise AS slr
     JOIN (
         SELECT siteid,
-        ST_Distance(ST_Transform(geometry, 2193), ST_GeomFromText('{query_loc_geom["geometry"][0]}', 2193)) AS distance
+        ST_Distance(ST_Transform(geometry, 2193), ST_GeomFromText(:geom, 2193)) AS distance
         FROM sea_level_rise
         ORDER BY distance
         LIMIT 1
     ) AS distances ON slr.siteid = distances.siteid;
     """
+    query = text(command_text).bindparams(
+        geom=str(query_loc_geom["geometry"][0])
+    )
     # Execute the query and retrieve the data as a GeoDataFrame
     query_data = gpd.GeoDataFrame.from_postgis(query, engine, geom_col="geometry")
     # Add the position information to the retrieved data

--- a/src/flood_model/flooded_buildings.py
+++ b/src/flood_model/flooded_buildings.py
@@ -124,7 +124,7 @@ def retrieve_building_outlines(engine: Engine, area_of_interest: gpd.GeoDataFram
     # Construct the query to find buildings within the area of interest
     query = f"""
     SELECT building_outline_id, geometry FROM nz_building_outlines
-    WHERE ST_INTERSECTS(nz_building_outlines.geometry, ST_GeomFromText('{aoi_wkt}', {crs}));
+    WHERE ST_INTERSECTS(nz_building_outlines.geometry, ST_GeomFromText(:aoi_wkt, {crs}));
     """
     # Execute the query and retrieve the result as a GeoDataFrame
     gdf = gpd.GeoDataFrame.from_postgis(query, engine, index_col="building_outline_id", geom_col="geometry")

--- a/src/flood_model/flooded_buildings.py
+++ b/src/flood_model/flooded_buildings.py
@@ -6,6 +6,7 @@ import rasterio as rio
 import shapely
 import xarray
 from sqlalchemy.engine import Engine
+from sqlalchemy.sql import text
 
 from src.flood_model.serve_model import create_building_database_views_if_not_exists
 
@@ -122,10 +123,14 @@ def retrieve_building_outlines(engine: Engine, area_of_interest: gpd.GeoDataFram
     aoi_wkt = area_of_interest["geometry"][0].wkt
     crs = area_of_interest.crs.to_epsg()
     # Construct the query to find buildings within the area of interest
-    query = f"""
+    command_text = """
     SELECT building_outline_id, geometry FROM nz_building_outlines
-    WHERE ST_INTERSECTS(nz_building_outlines.geometry, ST_GeomFromText(:aoi_wkt, {crs}));
+    WHERE ST_INTERSECTS(nz_building_outlines.geometry, ST_GeomFromText(:aoi_wkt, :crs));
     """
+    query = text(command_text).bindparams(
+        aoi_wkt=str(aoi_wkt),
+        crs=str(crs)
+    )
     # Execute the query and retrieve the result as a GeoDataFrame
     gdf = gpd.GeoDataFrame.from_postgis(query, engine, index_col="building_outline_id", geom_col="geometry")
     return gdf


### PR DESCRIPTION
DESCRIPTION OF PR: Convert `f` string format using `text` and `bindparams` from sqlalchemy.sql. However, `rain_table_name` is still left with `f` string due to  only two choices `rainfall_depth` and `rainfall_intensity`.

## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [ ] Test locally and ensure tests are passing
- [ ] Update documentation
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
