### PR TITLE
Hotfix - bug in geoserver styles fetching

### DIFF
--- a/src/flood_model/serve_model.py
+++ b/src/flood_model/serve_model.py
@@ -466,8 +466,11 @@ def style_exists(style_name: str) -> bool:
         f'{get_geoserver_url()}/styles/{style_name}.sld',
         auth=(EnvVariable.GEOSERVER_ADMIN_NAME, EnvVariable.GEOSERVER_ADMIN_PASSWORD)
     )
+    if response.status_code == HTTPStatus.OK:
+        return True
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        return False
     response.raise_for_status()
-    return response.status_code == HTTPStatus.OK
 
 
 def create_viridis_style_if_not_exists() -> None:

--- a/src/flood_model/serve_model.py
+++ b/src/flood_model/serve_model.py
@@ -461,6 +461,11 @@ def style_exists(style_name: str) -> bool:
     bool
         True if the style exists, although it may be empty.
         False if it does not exist.
+
+    Raises
+    -------
+    HTTPError
+        If geoserver responds with anything but OK or NOT_FOUND, raises it as an exception since it is unexpected.
     """
     response = requests.get(
         f'{get_geoserver_url()}/styles/{style_name}.sld',
@@ -470,7 +475,9 @@ def style_exists(style_name: str) -> bool:
         return True
     if response.status_code == HTTPStatus.NOT_FOUND:
         return False
-    response.raise_for_status()
+    # If it does not meet the expected results then raise an error
+    # Raise error manually, so we can configure the text
+    raise requests.HTTPError(response.text, response=response)
 
 
 def create_viridis_style_if_not_exists() -> None:


### PR DESCRIPTION
DESCRIPTION OF PR:

Closes #216
Resolves a geoserver bug where if the geoserver volume has not been initialised it breaks because of a 404 not found raising an exception when it should be explicitly checked for.

This occurred when I was fixing linting errors with the new linting checkers and simplified a boolean expression in an invalid way and missed it in my testing.

## Developer Checklist
- [X] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [X] Ensure these tests have the expected behaviour
  - [ ] Test locally and ensure tests are passing
- [X] Update documentation
  - [ ] Readme
  - [X] Docstrings
  - [ ] Comments
  - [ ] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
