### PR TITLE
261 Fix missing docker build files for www service.

### DIFF
--- a/visualisation/Dockerfile
+++ b/visualisation/Dockerfile
@@ -8,7 +8,7 @@ RUN npm ci --ignore-scripts
 # Copy License file into image root
 COPY ./LICENSE ../LICENSE
 # Copy visualisation source files into image
-COPY ["visualisation/*.js", "visualisation/*.json", "visualisation/.env.production", "./"]
+COPY ["visualisation/*.ts", "visualisation/*.json", "visualisation/.env.production", "visualisation/index.html", "./"]
 COPY visualisation/src/ src/
 COPY visualisation/public/ public/
 


### PR DESCRIPTION
DESCRIPTION OF PR:
Fixes #261
Blocked by: #263 

`docker compose build www` wasn't working and now it is.
I had this in a feature branch but it needs to be in the development branch.

## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [x] Test locally and ensure tests are passing
- [ ] Update documentation
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
