### PR TITLE
Update terriajs entrypoint to support Backend Hosts that use default ports

### DIFF
--- a/terriajs/catalog.json
+++ b/terriajs/catalog.json
@@ -192,7 +192,7 @@
           "type": "wps",
           "name": "MEDUSA Pollution source model",
           "description": "Model a rainfall event to identify sources of stormwater pollution.",
-          "url": "$BACKEND_HOST:$BACKEND_PORT/wps",
+          "url": "$BACKEND_URL/wps",
           "identifier": "medusa",
           "storeSupported": true
         }

--- a/terriajs/entrypoint.sh
+++ b/terriajs/entrypoint.sh
@@ -3,8 +3,16 @@
 # Used by docker to import environment variables into a docker container without baking them into the image.
 # Used when runtime environment variables are not enough, for example, when a config file needs to be written.
 
+# In a cloud environment there isn't a port value, this is derived from the use of https (port 443) so there's no need to include the port.
+BACKEND_URL=$BACKEND_HOST
+if [[ ! -z "$BACKEND_PORT" ]]; then
+  BACKEND_URL=$BACKEND_URL:$BACKEND_PORT
+fi
+
+export BACKEND_URL
+
 # List of variables to substitute
-ENV_VARS_TO_FILL='$CESIUM_ACCESS_TOKEN,$BACKEND_HOST,$BACKEND_PORT'
+ENV_VARS_TO_FILL='$CESIUM_ACCESS_TOKEN,$BACKEND_URL'
 
 # Substitute variables and save whole file to variable, sponge is not available to buffer.
 for FILE_TO_SUB in "wwwroot/config.json" "wwwroot/init/catalog.json"


### PR DESCRIPTION
DESCRIPTION OF PR:

When deploying Terria to the cloud, there's no need to specify the port as HTTPS is port 443 by default. 

This leads to the config being `api.my-url.com:` when no port is specified, which isn't correct. This is a quick entrypoint change to fix that.

## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [ ] Test locally and ensure tests are passing
- [ ] Update documentation
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki

## Reviewer Checklist
- [x] Check new code for code smells
- [x] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [x] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
