### PR TITLE
Lock conda-pack because newer versions break builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     build:
       context: .
       target: backend
-    image: lparkinson/backend-flood-resilience-dt:1.2
+    image: lparkinson/backend-flood-resilience-dt:1.3
     container_name: backend_digital_twin
     env_file:
       - .env
@@ -68,7 +68,7 @@ services:
     build:
       context: .
       target: celery_worker
-    image: lparkinson/celery-flood-resilience-dt:1.2
+    image: lparkinson/celery-flood-resilience-dt:1.3
     container_name: celery_worker_digital_twin
     restart: always
     env_file:
@@ -116,7 +116,7 @@ services:
 
   www:
     # Webserver for the website interface
-    image: lparkinson/www-flood-resilience-dt:1.2
+    image: lparkinson/www-flood-resilience-dt:1.3
     build:
       context: .
       dockerfile: visualisation/Dockerfile

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - conda-pack>=0.7.1
+  - conda-pack==0.7.1
   - python==3.11  # 11 for StrEnum
   - pip
   - python-dotenv==1.0.0


### PR DESCRIPTION
Closes #344 by locking conda pack version to a working version