### PR TITLE
Fix broken Sphinx dependency

### DIFF
--- a/autodoc/sphinx/requirements.txt
+++ b/autodoc/sphinx/requirements.txt
@@ -1,2 +1,2 @@
 sphinx_rtd_theme==2.0.0
-sphinx-autoapi==3.2.1
+sphinx-autoapi==3.6.0


### PR DESCRIPTION
DESCRIPTION OF PR:
A broken sphinx dependency was causing github action for documentation to fail reading.