### PR TITLE
Remove docker images because building on linux causes pulls on windows to be misconfigured and vice-versa

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,6 @@ services:
     build:
       context: .
       dockerfile: src/Dockerfile
-    image: lparkinson/flood-resilience-dt:2.1
     container_name: backend_digital_twin
     entrypoint: ["src/backend_entrypoint.sh"]
     env_file:
@@ -69,7 +68,6 @@ services:
     build:
       context: .
       dockerfile: src/Dockerfile
-    image: lparkinson/flood-resilience-dt:2.1
     container_name: celery_worker_digital_twin
     entrypoint: ["src/celery_worker_entrypoint.sh"]
     restart: always
@@ -98,7 +96,6 @@ services:
     build:
       context: .
       dockerfile: geoserver.Dockerfile
-    image: lparkinson/geoserver-dt:2.0
     container_name: geoserver_digital_twin
     volumes:
       - geoserver_data:/opt/geoserver_data
@@ -122,7 +119,6 @@ services:
     # Front-end using terria.js
     build:
       context: terriajs
-    image: lparkinson/terria-dt:2.0
     ports:
       - "${WWW_PORT}:3001"
     environment:


### PR DESCRIPTION
DESCRIPTION OF PR:
Further investigation into #344 found that `docker compose build` works for both windows WSL and ubuntu, but if images are built on one OS and then pulled on another they no longer work.

To resolve this I have removed the default ability to pull.

## Developer Checklist
- [x] Make code change
- [ ] Update tests
  - [ ] Update / create new tests
  - [ ] Ensure these tests have the expected behaviour
  - [x] Test locally and ensure tests are passing
- [ ] Update documentation
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki

## Reviewer Checklist
- [ ] Check new code for code smells
- [ ] Check new tests
  - [ ] Ensure adequate coverage
  - [ ] Check for code smells within tests
- [ ] Check if documentation needs updating
  - [ ] Readme
  - [ ] Docstrings
  - [ ] Comments
  - [ ] Wiki
