### PR TITLE
Use main project for new issues

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
-          project-url: https://github.com/orgs/GeospatialResearch/projects/1
+          project-url: https://github.com/orgs/GeospatialResearch/projects/3
           github-token: ${{ secrets.ADD_TO_PROJECT_ACTION_PAT }}


### PR DESCRIPTION
The old project board was mostly intended for the Ōtākaro Digital Twin project. This board is now closed. We will now be using https://github.com/orgs/GeospatialResearch/projects/3