### PR TITLE
Get basic python API documentation working again

### DIFF
--- a/autodoc/sphinx/conf.py
+++ b/autodoc/sphinx/conf.py
@@ -12,16 +12,16 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../eddie'))
-sys.path.insert(0, os.path.abspath('../../eddie_floodresilience'))
+
+sys.path.insert(0, os.path.abspath('../../src/eddie'))
 
 from __init__ import __version__
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'Flood Resilience Digital Twin (FReDT)'
-copyright = '2021-2025, Geospatial Research Institute Toi Hangarau'
+project = 'Environmental Digital Data Intelligence Engine (EDDIE)'
+copyright = '2021-2026, Geospatial Research Institute Toi Hangarau'
 author = 'Geospatial Research Institute Toi Hangarau'
 
 # The full version, including alpha/beta/rc tags
@@ -38,7 +38,7 @@ extensions = [
     'autoapi.extension',
 ]
 # -- Extension configuration -------------------------------------------------
-autoapi_dirs = ["../../eddie/", "../../eddie_floodresilience/"]
+autoapi_dirs = ["../../src"]
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/autodoc/sphinx/index.rst
+++ b/autodoc/sphinx/index.rst
@@ -3,7 +3,7 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Digital Twin for Flood Resilience in Aotearoa New Zealand's documentation!
+Welcome to the Environmental Digital Data Intelligence Engine (EDDIE) documentation!
 =====================================================================================
 
 REST API specification
@@ -15,7 +15,8 @@ Python codebase documentation
 ===============================
 
 .. toctree::
-   :maxdepth: 4
+   :titlesonly:
+   :maxdepth: 5
    :caption: Contents:
 
 

--- a/autodoc/sphinx/requirements.txt
+++ b/autodoc/sphinx/requirements.txt
@@ -1,2 +1,3 @@
-sphinx_rtd_theme==2.0.0
-sphinx-autoapi==3.6.0
+sphinx_rtd_theme==3.1.0
+sphinx-autoapi==3.8.0
+../../.


### PR DESCRIPTION
The sphinx autodoc has gone down. This PR is intended to restore it back to minimum. #380 is also proposed to improve our usage documentation standards